### PR TITLE
ci: change publish.yml to match Lupise's reusable workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,62 +1,56 @@
-name: Build and Publish Images
+name: Create and publish cyberacademy--exercises--ftp-mitm Docker server
+
 on:
-  pull_request:
-    branches:
-      - main
   push:
-    branches:
-      - main
-    tags:
-      - "*.*.*"
+    paths: [
+      '.github/workflows/publish.yml',
+      'src/**',
+      'Dockerfile',
+    ]
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+concurrency:
+  group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
-  publish:
-    name: Publish
+  build-and-push-image:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
     steps:
-      - name: Checkout
+      - name: Checkout repository
         uses: actions/checkout@v3
-      - name: Prepare
-        id: prep
-        uses: docker/metadata-action@v4.6.0
-        with:
-          images: |
-            ${{ github.repository_owner }}/ftp-server
-            ghcr.io/${{ github.repository_owner }}/ftp-server
-          tags: |
-            type=edge,branch=main
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Login to DockerHub
-        if: github.event_name != 'pull_request'
+
+      - name: Log in to the Container registry
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Login to GHCR
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build and Push
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
           context: .
-          platforms: linux/386,linux/amd64,linux/arm/v6,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.prep.outputs.tags }}
-          labels: ${{ steps.prep.outputs.labels }}
-      - name: Update Description
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Delete previous image with same name if exists
         continue-on-error: true
-        uses: peter-evans/dockerhub-description@v3
+        uses: camargo/delete-untagged-action@v1
         with:
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: ${{ github.repository_owner }}/ftp-server
-          short-description: ${{ github.event.repository.description }}
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Seen with Seb, we cannot use a reusable workflow on a forked public repository, so we C/C to content of the .github/workflows/build-push-docker-image.yml file.
We just change the workflow **name** and **on** attributes